### PR TITLE
Fix compilation on gcc-5, add basic CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Test scalr
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    strategy:      
+      matrix: 
+        gccVersion: [5, 7, 8, 9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: make test
+      run: make CC=gcc-${{matrix.gccVersion}} CXX=g++-${{matrix.gccVersion}} test
+

--- a/include/scalr/quantity.hpp
+++ b/include/scalr/quantity.hpp
@@ -410,9 +410,11 @@ constexpr quantity_sum_t<quantity<T1, U1>, quantity<T2, U2>> operator%(
 
 }  // namespace scalr
 
+namespace std {
 template <class Dimension1, class Ratio1, class Dimension2, class Ratio2>
-struct std::common_type<scalr::quantity<Dimension1, Ratio1>,
-                        scalr::quantity<Dimension2, Ratio2>> {
+struct common_type<scalr::quantity<Dimension1, Ratio1>,
+                   scalr::quantity<Dimension2, Ratio2>> {
   using type = scalr::quantity_sum_t<scalr::quantity<Dimension1, Ratio1>,
                                      scalr::quantity<Dimension2, Ratio2>>;
 };
+}  // namespace std


### PR DESCRIPTION
Hi, 

I've stumbled upon the following error when compiling with gcc 5.5: 

```
cd tests/build && g++-5 -g -std=c++11 -fPIC -O3 -pthread -fvisibility=hidden -Wall -Wextra main.o /home/runner/work/scalr/scalr/tests/test_scalar.cpp -o test_scalar -I/home/runner/work/scalr/scalr/include 
In file included from /home/runner/work/scalr/scalr/include/scalr/scalr.hpp:13:0,
                 from /home/runner/work/scalr/scalr/tests/test_scalar.cpp:6:
/home/runner/work/scalr/scalr/include/scalr/quantity.hpp:414:13: error: specialization of ‘template<class ... _Tp> struct std::common_type’ in different namespace [-fpermissive]
 struct std::common_type<scalr::quantity<Dimension1, Ratio1>,
             ^
In file included from /usr/include/c++/5/bits/move.h:57:0,
                 from /usr/include/c++/5/bits/stl_pair.h:59,
                 from /usr/include/c++/5/bits/stl_algobase.h:64,
                 from /usr/include/c++/5/bits/char_traits.h:39,
                 from /usr/include/c++/5/ios:40,
                 from /usr/include/c++/5/ostream:38,
                 from /usr/include/c++/5/iostream:39,
                 from /home/runner/work/scalr/scalr/tests/test_scalar.cpp:2:
/usr/include/c++/5/type_traits:2123:12: error:   from definition of ‘template<class ... _Tp> struct std::common_type’ [-fpermissive]
     struct common_type;
            ^
make: *** [test_scalar] Error 1
```

Apparently, this is a gcc bug that has been fixed in gcc 7 ([1, 2]). I've fixed the issue in the library by wrapping the template specialization in the `std` namespace, and added a CI descriptor to test the library using gcc 5, 7, 8, and 9 on Ubuntu 16 upon each commit. 

GCC 5 is a five-year-old C++14-compliant compiler so I think scalr should work with it too.

Cheers

[1] https://stackoverflow.com/questions/25594644/warning-specialization-of-template-in-different-namespace
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480