### PR TITLE
Support for scalr::abs(scalr::quantity) similar to std::chrono::abs()

### DIFF
--- a/include/scalr/quantity.hpp
+++ b/include/scalr/quantity.hpp
@@ -408,6 +408,14 @@ constexpr quantity_sum_t<quantity<T1, U1>, quantity<T2, U2>> operator%(
   return stype(stype(left).value() % stype(right).value());
 }
 
+template <typename Rep, typename Unit,
+          typename std::enable_if<quantity<Rep, Unit>::min() <
+                                      quantity<Rep, Unit>::zero(),
+                                  int>::type = 0>
+constexpr quantity<Rep, Unit> abs(const quantity<Rep, Unit>& value) {
+  return value >= value.zero() ? value : -value;
+}
+
 }  // namespace scalr
 
 namespace std {

--- a/include/scalr/unit.hpp
+++ b/include/scalr/unit.hpp
@@ -15,6 +15,15 @@
 
 namespace scalr {
 
+/* Class template physical unit type */
+template <class DimensionT, class Ratio = std::ratio<1>>
+struct unnamed_unit {
+  using dimension = DimensionT;
+  using ratio = Ratio;
+};
+
+namespace detail {
+
 template <intmax_t K>
 struct sign : std::integral_constant<intmax_t, (K < 0) ? -1 : 1> {};
 
@@ -37,24 +46,15 @@ struct lcm : std::integral_constant<intmax_t, (M / gcd<M, N>::value) * N> {};
 // gcrd(a/b, c/d) = gcd(ad, bc)/bd
 // gcrd(a/b, c/d) = gcd(a,c)/lcm(b,d) if gcd(a,b) = gcd(c,d) = 1
 template <class R1, class R2>
-struct ratio_gcrd : std::ratio<scalr::gcd<R1::num, R2::num>::value,
-                               scalr::lcm<R1::den, R2::den>::value> {};
+struct ratio_gcrd : std::ratio<scalr::detail::gcd<R1::num, R2::num>::value,
+                               scalr::detail::lcm<R1::den, R2::den>::value> {};
 
 // lcrm: least common rational multiple
 // lcrm(a/b, c/d) = lcm(ad, bc)/bd
 // lcrm(a/b, c/d) = lcm(a,c)/gcd(b,d) if gcd(a,b) = gcd(c,d) = 1
 template <class R1, class R2>
-struct ratio_lcrm : std::ratio<scalr::lcm<R1::num, R2::num>::value,
-                               scalr::gcd<R1::den, R2::den>::value> {};
-
-/* Class template physical unit type */
-template <class DimensionT, class Ratio = std::ratio<1>>
-struct unnamed_unit {
-  using dimension = DimensionT;
-  using ratio = Ratio;
-};
-
-namespace detail {
+struct ratio_lcrm : std::ratio<scalr::detail::lcm<R1::num, R2::num>::value,
+                               scalr::detail::gcd<R1::den, R2::den>::value> {};
 
 template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
@@ -115,9 +115,9 @@ struct sum<U1, U2> {
   static_assert(std::is_same<D1, D2>::value,
                 "unit dimensions must match for addition/subtraction");
 
-  using type =
-      typename make<D1, std::ratio<scalr::gcd<R1::num, R2::num>::value,
-                                   scalr::lcm<R1::den, R2::den>::value>>::type;
+  using type = typename make<
+      D1, std::ratio<scalr::detail::gcd<R1::num, R2::num>::value,
+                     scalr::detail::lcm<R1::den, R2::den>::value>>::type;
 };
 
 template <class U1, class U2, class... Un>

--- a/tests/test_scalar.cpp
+++ b/tests/test_scalar.cpp
@@ -169,7 +169,7 @@ TEST_CASE("Quantities") {
     CHECK(diff == scalr::nanoseconds(1198800));
   }
 
-  SECTION("Scalar Multiplication/Division/Modulo") {
+  SECTION("Scalar Multiplication/Division/Modulo/Absolute value") {
     using namespace scalr::literals;
     CHECK((12_mm * 1000.0) == (120_m / 10.0));
     CHECK((25.0 / 100_s) == (2.5 / 10_s));
@@ -177,6 +177,11 @@ TEST_CASE("Quantities") {
     CHECK((2_min % 17_s) == 1_s);
     CHECK((2_min / 17_s) == 7);        // 120/17 == 7 (integer division)
     CHECK((119.0_s / 17.0_s) == 7.0);  // 119/17 == 7 (float division)
+    CHECK(abs(-42_m) == 42_m);
+    CHECK(abs(42_m) == 42_m);
+    CHECK(abs(0_m) == 0_m);
+    CHECK(abs(-42.42_m) == 42.42_m);
+    CHECK(abs(42.42_m) == 42.42_m);
   }
 
   SECTION("Dimensional Multiplication/Division") {


### PR DESCRIPTION
Hey, 

I've moved the helper structs in unit.hpp to the `detail` namespace and added the function `scalr::abs()` as discussed in #4 

Cheers

Closes #4