### PR TITLE
quantity: removed operator bool() to avoid implicit conversion

### DIFF
--- a/include/scalr/quantity.hpp
+++ b/include/scalr/quantity.hpp
@@ -197,8 +197,6 @@ struct quantity {
     return *this;
   }
 
-  operator bool() const { return bool(value_); }
-
   static constexpr quantity zero() noexcept {
     return quantity(linear_range<value_type>::zero());
   }


### PR DESCRIPTION
Hi, 

as discussed in #7, the `operator bool()` has been removed

Cheers